### PR TITLE
Prototype: Filled top bar with dummy elements (#40)

### DIFF
--- a/src/ui/panels/top_bar.rs
+++ b/src/ui/panels/top_bar.rs
@@ -1,16 +1,101 @@
+use crate::ui::meter::Meter;
+use crate::ui::MeterHandle;
+use crate::ui::{icons::IconCode, Icon, PanelEvent};
 use vizia::prelude::*;
 
-use crate::ui::{icons::IconCode, Icon, PanelEvent};
+#[derive(Lens)]
+pub struct Data {
+    input_l: f32,
+    input_r: f32,
+}
+
+impl Model for Data {}
 
 pub fn top_bar(cx: &mut Context) {
     HStack::new(cx, |cx| {
-        Button::new(
-            cx,
-            |cx| cx.emit(PanelEvent::TogglePianoRoll),
-            |cx| Icon::new(cx, IconCode::Piano, 24.0, 16.0),
-        )
-        .left(Stretch(1.0))
-        .right(Pixels(20.0));
+        Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Menu, 24.0, 16.0))
+            .class("top_bar_menu");
+
+        // This is all just dummy content and it doesn't do anything
+        HStack::new(cx, |cx| {
+            VStack::new(cx, |cx| {
+                HStack::new(cx, |cx| {
+                    Label::new(cx, "130.00");
+                    Label::new(cx, "TAP");
+                });
+                HStack::new(cx, |cx| {
+                    Label::new(cx, "4/4");
+                    Label::new(cx, "GRV");
+                });
+            })
+            .class("top_play_left");
+
+            HStack::new(cx, |cx| {
+                Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Play, 24.0, 23.0));
+                Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Stop, 24.0, 23.0));
+                Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Record, 24.0, 23.0));
+            })
+            .class("top_play_center")
+            .top(Stretch(1.0))
+            .bottom(Stretch(1.0));
+
+            VStack::new(cx, |cx| {
+                Label::new(cx, "AUDIO");
+                Label::new(cx, "OVERWRITE");
+            })
+            .class("top_play_right");
+        })
+        .class("top_bar_play");
+
+        HStack::new(cx, |cx| {
+            VStack::new(cx, |cx| {
+                HStack::new(cx, |cx| {
+                    Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Hierarchy, 24.0, 16.0));
+                    Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Grid, 24.0, 16.0));
+                    Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Mixer, 24.0, 16.0));
+                    Button::new(
+                        cx,
+                        |cx| cx.emit(PanelEvent::TogglePianoRoll),
+                        |cx| Icon::new(cx, IconCode::Piano, 24.0, 16.0),
+                    );
+                });
+                HStack::new(cx, |cx| {
+                    Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Automation, 24.0, 16.0));
+                    Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Sample, 24.0, 16.0));
+                    Button::new(
+                        cx,
+                        |cx| {},
+                        |cx| Icon::new(cx, IconCode::DrumSequencer, 24.0, 16.0),
+                    );
+                    Button::new(cx, |cx| {}, |cx| Icon::new(cx, IconCode::Stack, 24.0, 16.0));
+                });
+            })
+            .class("top_bar_select_container");
+
+            HStack::new(cx, |cx| {
+                VStack::new(cx, |cx| {
+                    Label::new(cx, "Oscilloscope");
+                    VStack::new(cx, |cx| {
+                        Data { input_l: 0.42, input_r: 0.69 }.build(cx);
+                        Meter::new(cx, Data::input_l)
+                            .line_color(Color::rgb(245, 78, 71))
+                            .class("top_bar_peak");
+                        Meter::new(cx, Data::input_r)
+                            .line_color(Color::rgb(245, 78, 71))
+                            .class("top_bar_peak");
+                    })
+                    .class("top_bar_peak_container");
+                })
+                .class("top_bar_audio_graph_container");
+
+                VStack::new(cx, |cx| {
+                    Label::new(cx, "Usage Graph").top(Stretch(1.0)).bottom(Stretch(1.0));
+                })
+                .class("top_bar_usage_graph_container");
+            })
+            .class("top_bar_graph_container");
+        })
+        .class("top_bar_right_container");
     })
     .class("top_bar");
 }

--- a/src/ui/resources/themes/default_theme.css
+++ b/src/ui/resources/themes/default_theme.css
@@ -35,6 +35,72 @@
     child-bottom: 1s;
     background-color: #141112;
     height: 64px;
+    col-between: 1s;
+}
+
+.top_bar_menu {
+    left: 8px;
+}
+
+.top_bar_play {
+    position: self-directed;
+    left: 1s;
+    right: 1s;
+    width: 100px;
+    col-between: 30px;
+}
+
+.top_play_center {
+    col-between: 10px;
+}
+
+.top_bar_right_container {
+    right: 8px;
+    left: 1s;
+    /*Same problem as the select container*/
+    width: 336px;
+}
+
+.top_bar_graph_container {
+    col-between: 8px;
+}
+
+.top_bar_select_container {
+    /*For some reason the button container is growing on the right 
+    side as the window grows in order to keep the left side in the middle.
+    Setting the width to 4*button_width + spaces between fixes this*/
+    width: 136px;
+}
+
+.top_bar_select_container > hstack > button {
+    left: 5px;
+    right: 5px;
+}
+
+.top_bar_audio_graph_container {
+    child-space: 3px;
+    background-color: #211C1E;
+    border-radius: 2px;
+    width: 100px;
+}
+
+.top_bar_peak_container {
+    row-between: 1s;
+    child-space: 3px;
+    background-color: #141112;
+    border-radius: 3px;
+    width: 100px;
+}
+
+.top_bar_peak {
+    height: 5px;
+}
+
+.top_bar_usage_graph_container {
+    child-space: 3px;
+    background-color: #211C1E;
+    border-radius: 2px;
+    width: 100px;
 }
 
 .bottom_bar {

--- a/src/ui/views/meter.rs
+++ b/src/ui/views/meter.rs
@@ -1,0 +1,503 @@
+use vizia::prelude::*;
+use vizia::vg::{Color, Paint, Path};
+
+use vizia::style::Color as Col;
+
+/// The direction the meter bar shows the peak in.
+///
+/// This is also used to decide the orientation of the meter
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Data)]
+pub enum Direction {
+    /// The standard vertical meter direction
+    North,
+    /// The standard horizontal meter direction
+    East,
+    /// The inverted direction from the standard vertical meter
+    South,
+    /// The inverted direction from the standard horizontal meter
+    West,
+    /// Automatically calculate the direction.
+    /// By default the horizontal meter will move east and the vertical meter will move north
+    Automatic,
+}
+
+enum InternalDirection {
+    /// The standard vertical meter direction
+    North,
+    /// The standard horizontal meter direction
+    East,
+    /// The inverted direction from the standard vertical meter
+    South,
+    /// The inverted direction from the standard horizontal meter
+    West,
+}
+
+/// The different events that can be called to update states in the meter
+#[derive(Debug, Clone)]
+pub enum MeterEvents {
+    /// Update the input value
+    /// This also automatically smooths out the input and sets the max peak
+    UpdatePosition(f32),
+    /// Change the scale that is used to map the meter positions
+    ChangeMeterScale(MeterScale),
+    /// Change the amount of smoothing that is applied to the meter.
+    /// Lower - More smoothing
+    /// Higher - Less smoothing
+    ChangeSmoothingFactor(f32),
+    /// Change the speed at which the max peak drops
+    ChangePeakDropSpeed(f32),
+    /// Change the duration that the max peak stays in place
+    ChangeMaxHoldTime(i32),
+    /// Change the colour of the main peak bar
+    ChangeBarColor(Col),
+    /// Change the colour of the max peak line
+    ChangeLineColor(Col),
+    /// Change the coloured sections
+    ChangeSections(Vec<(f32, f32, Col)>),
+    /// Change the direction of the meter
+    ChangeDirection(Direction),
+}
+
+/// Different scales to map the values with
+#[derive(Debug, Clone, Copy)]
+pub enum MeterScale {
+    /// A linear one to one representation
+    Linear,
+    /// A logarithmic approximation
+    /// f(x) = x^0.25
+    Logarithmic,
+}
+
+/// A meter represents input values in a range of \[0,1\].
+/// As an input it requires a lens. By default it scales the input values logarithmically.
+/// This can be changed using a handle.
+///
+/// It allows you to show them as a bar that grows in each cardinal direction.
+///
+/// By default it smooths out the input values. The amount of smoothing can be controlled using the `smoothing_factor(f32)` handle.
+/// The value should be in (0,1\] where a value of 1.0 disables smoothing. The lower the value, the stronger the smoothing.
+///
+/// Example:
+/// ```rust
+/// Data{input: 0.42}.build(cx);
+///
+/// // Simple meter
+/// Meter::new(cx, Data::input, Direction::LeftToRight);
+///
+/// // Linear Meter without smoothing
+/// Meter::new(cx, Data::input, Direction::LeftToRight)
+/// .scale(MeterScale::Linear)
+/// .smoothing_factor(1.0);
+/// ```
+#[derive(Lens)]
+pub struct Meter {
+    /// The position of the meter bar in [0,1]
+    pos: f32,
+    /// The scale that is used to map the input to the meter
+    scale: MeterScale,
+    /// The position of the max peak in [0,1]
+    max: f32,
+    /// A ticker to keep track of when the max peak should start dropping
+    max_delay_ticker: i32,
+    /// The speed at which the max peak drops
+    max_drop_speed: f32,
+    /// The time that the max peak should stand still for
+    max_hold_time: i32,
+    /// The smoothing factor in (0,1]
+    smoothing_factor: f32,
+    /// The direction the peak meter should grow in
+    direction: Direction,
+    /// The colour of the peak line
+    //NOTE: Replace this by custom style properties once they're implemented
+    line_color: Col,
+    /// The sections denoting where the bar changes colours
+    /// (start, stop, colour)
+    sections: Vec<(f32, f32, Col)>,
+}
+
+impl Meter {
+    pub fn new<L: Lens<Target = f32>>(cx: &mut Context, lens: L) -> Handle<Self> {
+        // Default values for the sections. The positions are pretty arbitrary
+        let mut sections = Vec::new();
+        sections.push((0.0, 0.4, Col::rgb(0, 244, 70)));
+        sections.push((0.4, 0.6, Col::rgb(244, 220, 0)));
+        sections.push((0.6, 0.8, Col::rgb(244, 132, 0)));
+        sections.push((0.8, 1.0, Col::rgb(245, 78, 71)));
+
+        Self {
+            pos: lens.get(cx),
+            scale: MeterScale::Logarithmic,
+            max: 0.0,
+            max_delay_ticker: 0,
+            max_drop_speed: 0.006,
+            max_hold_time: 25,
+            smoothing_factor: 0.05,
+            direction: Direction::Automatic,
+            line_color: Col::black(),
+            sections,
+        }
+        .build(cx, move |cx| {
+            // Bind the input lens to the meter event to update the position
+            Binding::new(cx, lens, |cx, value| {
+                cx.emit(MeterEvents::UpdatePosition(value.get(cx)));
+            });
+        })
+    }
+}
+
+impl View for Meter {
+    fn element(&self) -> Option<&'static str> {
+        Some("meter")
+    }
+
+    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+        event.map(|meter_event, _| {
+            match meter_event {
+                MeterEvents::UpdatePosition(n) => {
+                    let new_pos = match self.scale {
+                        MeterScale::Linear => (*n).abs(),
+                        MeterScale::Logarithmic => {
+                            // Logarithmic approximation for 60db dynamic range
+                            // Source: https://www.dr-lex.be/info-stuff/volumecontrols.html
+                            (*n).abs().powf(0.25)
+                        }
+                    };
+
+                    // Smoothing source: https://stackoverflow.com/a/39417788
+                    // Essentially it closes in to the new position by
+                    // subtracting the difference between the current position and new position
+                    // and multiplying that by the smoothing_factor.
+                    // This a smaller factor causes stronger smoothing.
+                    // NOTE: Maybe use (1.0 - smoothing_factor) at some point to allow the factor to create the least amount of smoothing at 0.0
+                    self.pos = self.pos - self.smoothing_factor * (self.pos - new_pos);
+
+                    // If the new position is higher than the current max peak update it
+                    if self.max < self.pos {
+                        self.max = self.pos;
+                        self.max_delay_ticker = self.max_hold_time;
+                    }
+
+                    // Once the ticker for the max peak is done start dropping it until it reaches 0
+                    if self.max_delay_ticker == 0 {
+                        self.max -= self.max_drop_speed;
+
+                        if self.max < 0.0 {
+                            self.max = 0.0;
+                        }
+                    } else {
+                        self.max_delay_ticker -= 1;
+                    }
+
+                    cx.style().needs_redraw = true;
+                }
+                MeterEvents::ChangeMeterScale(scale) => {
+                    self.scale = *scale;
+                }
+                MeterEvents::ChangePeakDropSpeed(n) => {
+                    self.max_drop_speed = *n;
+                }
+                MeterEvents::ChangeSmoothingFactor(n) => {
+                    self.smoothing_factor = *n;
+                }
+                MeterEvents::ChangeMaxHoldTime(n) => {
+                    self.max_hold_time = *n;
+                }
+                MeterEvents::ChangeBarColor(col) => {
+                    let mut sections = Vec::new();
+                    sections.push((0.0, 0.4, *col));
+                    self.sections = sections;
+                }
+                MeterEvents::ChangeLineColor(col) => {
+                    self.line_color = *col;
+                }
+                MeterEvents::ChangeSections(sec) => {
+                    self.sections = (*sec).to_owned();
+                }
+                MeterEvents::ChangeDirection(dir) => {
+                    self.direction = *dir;
+                }
+            }
+        });
+    }
+
+    fn draw(&self, cx: &mut DrawContext<'_>, canvas: &mut Canvas) {
+        let entity = cx.current();
+
+        let bounds = cx.cache().get_bounds(entity);
+
+        //Skip meters with no width or no height
+        if bounds.w == 0.0 || bounds.h == 0.0 {
+            return;
+        }
+        let width = bounds.w;
+        let height = bounds.h;
+
+        // TODO:
+        // Whole meter background
+        // Border
+        // Border shape
+        // Padding
+        // Space
+
+        let pos_x = cx.cache().get_posx(entity);
+        let pos_y = cx.cache().get_posy(entity);
+        let value = self.pos;
+        let max = self.max;
+
+        let opacity = cx.cache().get_opacity(entity);
+
+        let mut line_color: Color = self.line_color.into();
+        line_color.set_alphaf(line_color.a * opacity);
+
+        // Calculate the border radiuses
+        // This is taken from the default draw implementation of Views
+        let border_radius_top_left = cx
+            .border_radius_top_left(entity)
+            .unwrap_or_default()
+            .value_or(bounds.w.min(bounds.h), 0.0);
+
+        let border_radius_top_right = cx
+            .border_radius_top_right(entity)
+            .unwrap_or_default()
+            .value_or(bounds.w.min(bounds.h), 0.0);
+
+        let border_radius_bottom_left = cx
+            .border_radius_bottom_left(entity)
+            .unwrap_or_default()
+            .value_or(bounds.w.min(bounds.h), 0.0);
+        let border_radius_bottom_right = cx
+            .border_radius_bottom_right(entity)
+            .unwrap_or_default()
+            .value_or(bounds.w.min(bounds.h), 0.0);
+
+        // Convert the user-side direction into the internal direction without the calculated state
+        let direction = match self.direction {
+            Direction::North => InternalDirection::North,
+            Direction::South => InternalDirection::South,
+            Direction::East => InternalDirection::East,
+            Direction::West => InternalDirection::West,
+            Direction::Automatic => {
+                if width > height {
+                    InternalDirection::East
+                } else {
+                    InternalDirection::North
+                }
+            }
+        };
+
+        // Create variables for the rectangle
+        let bar_x;
+        let bar_y;
+        let bar_w;
+        let bar_h;
+
+        let line_x1;
+        let line_x2;
+        let line_y1;
+        let line_y2;
+
+        let grad_x_start;
+        let grad_x_end;
+        let grad_y_start;
+        let grad_y_end;
+
+        // Build the start and end positions of the back and bar line
+        // according to the direction the meter is going and the value the meter is showing
+        match direction {
+            InternalDirection::North => {
+                bar_x = pos_x;
+                bar_y = pos_y + (1.0 - value) * height;
+
+                bar_w = width;
+                bar_h = value * height;
+
+                line_x1 = pos_x;
+                line_x2 = pos_x + width;
+
+                line_y1 = pos_y + (1.0 - max) * height;
+                line_y2 = line_y1;
+
+                grad_x_start = pos_x;
+                grad_x_end = pos_x;
+
+                grad_y_start = pos_y + height;
+                grad_y_end = pos_y;
+            }
+            InternalDirection::South => {
+                bar_x = pos_x;
+                bar_y = pos_y;
+
+                bar_w = width;
+                bar_h = value * height;
+
+                line_x1 = pos_x;
+                line_x2 = pos_x + width;
+
+                line_y1 = pos_y + max * height;
+                line_y2 = line_y1;
+
+                grad_x_start = pos_x;
+                grad_x_end = pos_x;
+
+                grad_y_start = pos_y;
+                grad_y_end = pos_y + height;
+            }
+            InternalDirection::East => {
+                bar_x = pos_x;
+                bar_y = pos_y;
+
+                bar_w = value * width;
+                bar_h = height;
+
+                line_x1 = pos_x + max * width;
+                line_x2 = pos_x + max * width;
+
+                line_y1 = pos_y;
+                line_y2 = pos_y + height;
+
+                grad_x_start = pos_x;
+                grad_x_end = pos_x + width;
+
+                grad_y_start = pos_y;
+                grad_y_end = pos_y;
+            }
+            InternalDirection::West => {
+                bar_x = pos_x + (1.0 - value) * width;
+                bar_y = pos_y;
+
+                bar_w = value * width;
+                bar_h = height;
+
+                line_x1 = pos_x + (1.0 - max) * width;
+                line_x2 = pos_x + (1.0 - max) * width;
+
+                line_y1 = pos_y;
+                line_y2 = pos_y + height;
+
+                grad_x_start = pos_x + width;
+                grad_x_end = pos_x;
+
+                grad_y_start = pos_y;
+                grad_y_end = pos_y;
+            }
+        };
+
+        let mut bar_path = Path::new();
+        bar_path.rounded_rect_varying(
+            bar_x,
+            bar_y,
+            bar_w,
+            bar_h,
+            border_radius_top_left,
+            border_radius_top_right,
+            border_radius_bottom_left,
+            border_radius_bottom_right,
+        );
+
+        // Convert our sections into a list femtovg can use
+        let mut femtovg_sections: Vec<(f32, vizia::vg::Color)> = Vec::new();
+
+        for (start, stop, col) in &self.sections {
+            femtovg_sections.push((*start, (*col).into()));
+            femtovg_sections.push((*stop, (*col).into()));
+        }
+
+        // Draw the gradient
+        let mut bar_paint = Paint::linear_gradient_stops(
+            grad_x_start,
+            grad_y_start,
+            grad_x_end,
+            grad_y_end,
+            &femtovg_sections,
+        );
+
+        canvas.fill_path(&mut bar_path, bar_paint);
+
+        // Draw the peak line
+        let mut line_path = Path::new();
+        line_path.move_to(line_x1, line_y1);
+        line_path.line_to(line_x2, line_y2);
+
+        let mut line_paint = Paint::color(line_color);
+        line_paint.set_line_width(2.0);
+
+        canvas.stroke_path(&mut line_path, line_paint)
+    }
+}
+
+pub trait MeterHandle {
+    fn peak_drop_speed(self, val: impl Res<f32>) -> Self;
+    fn smoothing_factor(self, val: impl Res<f32>) -> Self;
+    fn bar_color(self, val: impl Res<Col>) -> Self;
+    fn max_hold_time(self, val: impl Res<i32>) -> Self;
+    fn line_color(self, val: impl Res<Col>) -> Self;
+    fn scale(self, val: impl Res<MeterScale>) -> Self;
+    fn sections(self, val: impl Res<Vec<(f32, f32, Col)>>) -> Self;
+    fn direction(self, val: impl Res<Direction>) -> Self;
+}
+
+impl MeterHandle for Handle<'_, Meter> {
+    fn peak_drop_speed(self, val: impl Res<f32>) -> Self {
+        val.set_or_bind(self.cx, self.entity, |cx, entity, value| {
+            cx.emit_to(entity, MeterEvents::ChangePeakDropSpeed(value));
+        });
+
+        self
+    }
+
+    fn smoothing_factor(self, val: impl Res<f32>) -> Self {
+        val.set_or_bind(self.cx, self.entity, |cx, entity, value| {
+            cx.emit_to(entity, MeterEvents::ChangeSmoothingFactor(value));
+        });
+
+        self
+    }
+
+    fn bar_color(self, val: impl Res<Col>) -> Self {
+        val.set_or_bind(self.cx, self.entity, |cx, entity, value| {
+            cx.emit_to(entity, MeterEvents::ChangeBarColor(value));
+        });
+
+        self
+    }
+
+    fn line_color(self, val: impl Res<Col>) -> Self {
+        val.set_or_bind(self.cx, self.entity, |cx, entity, value| {
+            cx.emit_to(entity, MeterEvents::ChangeLineColor(value));
+        });
+
+        self
+    }
+
+    fn max_hold_time(self, val: impl Res<i32>) -> Self {
+        val.set_or_bind(self.cx, self.entity, |cx, entity, value| {
+            cx.emit_to(entity, MeterEvents::ChangeMaxHoldTime(value));
+        });
+
+        self
+    }
+
+    fn scale(self, val: impl Res<MeterScale>) -> Self {
+        val.set_or_bind(self.cx, self.entity, |cx, entity, value| {
+            cx.emit_to(entity, MeterEvents::ChangeMeterScale(value));
+        });
+
+        self
+    }
+
+    fn sections(self, val: impl Res<Vec<(f32, f32, Col)>>) -> Self {
+        val.set_or_bind(self.cx, self.entity, |cx, entity, mut value| {
+            cx.emit_to(entity, MeterEvents::ChangeSections(value));
+        });
+
+        self
+    }
+
+    fn direction(self, val: impl Res<Direction>) -> Self {
+        val.set_or_bind(self.cx, self.entity, |cx, entity, mut value| {
+            cx.emit_to(entity, MeterEvents::ChangeDirection(value));
+        });
+
+        self
+    }
+}

--- a/src/ui/views/mod.rs
+++ b/src/ui/views/mod.rs
@@ -1,5 +1,7 @@
 pub mod resizable_stack;
 pub use resizable_stack::*;
 
+pub mod meter;
+pub use meter::*;
 pub mod icon;
 pub use icon::*;


### PR DESCRIPTION
* add some meters

* Simple implementation of top right elements

* Update the meter to reflect the new Vizia femtovg reexport

* Refactored top button styling, because I forgot how to css before

* Added newest meter version that includes logarithmic scaling

* Removed debug print

* oops, forgot the debug css

* Added newest meter version that includes logarithmic scaling

* Add hamburger in top-left

* Centered the play controls. Annoyingly this required setting some pixel widths of elements

* Filld the Play button space with dummy elements

* Documentation

* Fix for breaking changes of new Vizia version

* Implemented sections into meter view

* Updated the Direction names

* Updated top_bar direction names

* Removed direction from the initialization and made it be calculated by default

* Renamed calculated direction to automatic

* Doc string mix up

* Update bar_color to use sections

* Update meter for vizia prelude update

Co-authored-by: George Atkinson <geomyles@yahoo.co.uk>